### PR TITLE
Fix raise statement test context setup

### DIFF
--- a/crates/depyler-core/src/rust_gen.rs
+++ b/crates/depyler-core/src/rust_gen.rs
@@ -882,6 +882,7 @@ mod tests {
         use crate::hir::Literal;
 
         let mut ctx = create_test_context();
+        ctx.current_function_can_fail = true; // Function returns Result, so raise becomes return Err
         let exc = Some(HirExpr::Literal(Literal::String("Error".to_string())));
 
         let result = codegen_raise_stmt(&exc, &mut ctx).unwrap();
@@ -894,6 +895,7 @@ mod tests {
     #[test]
     fn test_codegen_raise_stmt_bare() {
         let mut ctx = create_test_context();
+        ctx.current_function_can_fail = true; // Function returns Result, so raise becomes return Err
 
         let result = codegen_raise_stmt(&None, &mut ctx).unwrap();
         assert_eq!(


### PR DESCRIPTION
Two tests for raise statement codegen were failing because they didn't properly set up the test context:
- test_codegen_raise_stmt_with_exception
- test_codegen_raise_stmt_bare

The tests expected 'return Err(...)' output but didn't set 'current_function_can_fail = true' in the context. Without this flag, the codegen correctly generates 'panic!(...)' instead.

Added 'ctx.current_function_can_fail = true' to both tests to match their expectations.

Test Results:
- All 458 tests pass
- No regressions
- Test now correctly validates Result-returning functions

This was a test bug, not a transpiler bug - the transpiler correctly implements the logic:
1. If exception is handled by try block → panic!
2. If function can fail → return Err
3. Otherwise → panic!