### PR TITLE
[FIX] Add missing tempfile dev-dependency for tests

### DIFF
--- a/crates/depyler-core/Cargo.toml
+++ b/crates/depyler-core/Cargo.toml
@@ -42,3 +42,4 @@ optional = true
 insta.workspace = true
 proptest.workspace = true
 quickcheck.workspace = true
+tempfile.workspace = true


### PR DESCRIPTION
- Added tempfile.workspace = true to depyler-core dev-dependencies
- Required by depyler_0333_exception_scope_test.rs for compilation tests
- Fixes compilation error in test suite