### PR TITLE
[FIX] Add constants field to remaining HirModule test initializations

### DIFF
--- a/tests/operator_tests.rs
+++ b/tests/operator_tests.rs
@@ -165,6 +165,7 @@ fn test_all_arithmetic_operators() {
             type_aliases: vec![],
             protocols: vec![],
             classes: vec![],
+            constants: vec![],
         };
 
         let type_mapper = TypeMapper::default();
@@ -245,6 +246,7 @@ fn test_comparison_operators() {
             type_aliases: vec![],
             protocols: vec![],
             classes: vec![],
+            constants: vec![],
         };
 
         let type_mapper = TypeMapper::default();
@@ -284,6 +286,7 @@ fn test_logical_operators() {
             type_aliases: vec![],
             protocols: vec![],
             classes: vec![],
+            constants: vec![],
         };
 
         let type_mapper = TypeMapper::default();
@@ -329,6 +332,7 @@ fn test_bitwise_operators() {
             type_aliases: vec![],
             protocols: vec![],
             classes: vec![],
+            constants: vec![],
         };
 
         let type_mapper = TypeMapper::default();


### PR DESCRIPTION
Complete the fix for missing constants field in operator_tests.rs by adding it to the 4 remaining HirModule initializations that use 12-space indentation (inside test loops).

Files affected:
- tests/operator_tests.rs (4 additional occurrences at lines 167, 247, 286, 331)

Verification:
- cargo build --workspace: ✅ PASS (0 errors)
- All HirModule initializations now include constants field: ✅ PASS