### PR TITLE
fix: remove hard-coded paths from source code

### DIFF
--- a/crates/depyler-corpus/src/main.rs
+++ b/crates/depyler-corpus/src/main.rs
@@ -214,11 +214,15 @@ fn main() -> anyhow::Result<()> {
 /// Default corpus path (reprorusted-python-cli)
 fn default_corpus_path() -> PathBuf {
     // Check common locations
-    let candidates = [
+    let mut candidates = vec![
         PathBuf::from("../reprorusted-python-cli/examples"),
-        PathBuf::from("/home/noah/src/reprorusted-python-cli/examples"),
         PathBuf::from("examples"),
     ];
+    if let Some(home) = std::env::var_os("HOME") {
+        let mut home_path = PathBuf::from(home);
+        home_path.push("src/reprorusted-python-cli/examples");
+        candidates.push(home_path);
+    }
 
     for path in &candidates {
         if path.exists() {

--- a/crates/depyler-corpus/src/registry.rs
+++ b/crates/depyler-corpus/src/registry.rs
@@ -102,10 +102,14 @@ impl CorpusRegistry {
     pub fn with_defaults() -> Self {
         let mut registry = Self::new();
 
+        let src_dir = std::env::var_os("HOME")
+            .map(|h| PathBuf::from(h).join("src"))
+            .unwrap_or_else(|| PathBuf::from(".."));
+
         // Corpus 1: reprorusted-python-cli (Original)
         let mut entry1 = CorpusEntry::new(
             "reprorusted-python-cli",
-            PathBuf::from("/home/noah/src/reprorusted-python-cli"),
+            src_dir.join("reprorusted-python-cli"),
         )
         .with_description("Original Python CLI examples - mixed type annotations")
         .with_github("https://github.com/paiml/reprorusted-python-cli");
@@ -116,7 +120,7 @@ impl CorpusRegistry {
         // Corpus 2: reprorusted-std-only (Stdlib)
         let mut entry2 = CorpusEntry::new(
             "reprorusted-std-only",
-            PathBuf::from("/home/noah/src/reprorusted-std-only"),
+            src_dir.join("reprorusted-std-only"),
         )
         .with_description("Python stdlib examples - std-only transpilation targets")
         .with_github("https://github.com/paiml/reprorusted-std-only")
@@ -128,7 +132,7 @@ impl CorpusRegistry {
         // Corpus 3: fully-typed-reprorusted-python-cli (Typed CLI)
         let mut entry3 = CorpusEntry::new(
             "fully-typed-reprorusted-python-cli",
-            PathBuf::from("/home/noah/src/fully-typed-reprorusted-python-cli"),
+            src_dir.join("fully-typed-reprorusted-python-cli"),
         )
         .with_description("Fully typed Python CLI utilities - strict type annotations")
         .with_github("https://github.com/paiml/fully-typed-reprorusted-python-cli")

--- a/crates/depyler-oracle/src/github_corpus.rs
+++ b/crates/depyler-oracle/src/github_corpus.rs
@@ -413,9 +413,10 @@ mod tests {
     #[test]
     fn test_load_real_oip_data_if_exists() {
         // Try to load real OIP training data if available
-        let oip_path = std::path::Path::new(
-            "/home/noah/src/organizational-intelligence-plugin/training-data.json",
-        );
+        let oip_path_buf = std::env::var_os("HOME")
+            .map(|h| std::path::PathBuf::from(h).join("src/organizational-intelligence-plugin/training-data.json"))
+            .unwrap_or_else(|| std::path::PathBuf::from("../organizational-intelligence-plugin/training-data.json"));
+        let oip_path = oip_path_buf.as_path();
 
         if oip_path.exists() {
             let oip_data = load_oip_training_data(oip_path).expect("Should load OIP data");

--- a/crates/depyler/src/report_cmd/mod.rs
+++ b/crates/depyler/src/report_cmd/mod.rs
@@ -63,11 +63,15 @@ pub fn handle_report_command(args: ReportArgs) -> Result<()> {
 
 /// Find default corpus path
 pub fn default_corpus_path() -> PathBuf {
-    let candidates = [
-        PathBuf::from("/home/noah/src/reprorusted-python-cli/examples"),
+    let mut candidates = vec![
         PathBuf::from("../reprorusted-python-cli/examples"),
         PathBuf::from("./examples"),
     ];
+    if let Some(home) = std::env::var_os("HOME") {
+        let mut home_path = PathBuf::from(home);
+        home_path.push("src/reprorusted-python-cli/examples");
+        candidates.insert(0, home_path);
+    }
 
     for path in &candidates {
         if path.exists() {


### PR DESCRIPTION
## Summary
- Replace 6 hard-coded `/home/noah` absolute paths in 4 source files with `$HOME`-based resolution or relative path fallbacks
- Affected crates: `depyler`, `depyler-corpus`, `depyler-oracle`
- Pattern: use `std::env::var_os("HOME")` with relative path fallback so builds work in any environment (including clean-room CI)

## Test plan
- [x] `cargo check` passes cleanly
- [ ] Clean-room CI gate passes (Mode A + Mode B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)