### PR TITLE
style: cargo fmt (unified CI prep)

### DIFF
--- a/crates/depyler-analysis/src/inlining.rs
+++ b/crates/depyler-analysis/src/inlining.rs
@@ -103,11 +103,7 @@ pub enum InliningReason {
 
 impl InliningAnalyzer {
     pub fn new(config: InliningConfig) -> Self {
-        Self {
-            config,
-            call_graph: CallGraph::default(),
-            function_metrics: HashMap::new(),
-        }
+        Self { config, call_graph: CallGraph::default(), function_metrics: HashMap::new() }
     }
 
     /// Analyze a program and determine which functions should be inlined
@@ -132,11 +128,8 @@ impl InliningAnalyzer {
         decisions: &HashMap<String, InliningDecision>,
     ) -> HirProgram {
         // Create a map of functions for quick lookup
-        let function_map: HashMap<String, HirFunction> = program
-            .functions
-            .iter()
-            .map(|f| (f.name.clone(), f.clone()))
-            .collect();
+        let function_map: HashMap<String, HirFunction> =
+            program.functions.iter().map(|f| (f.name.clone(), f.clone())).collect();
 
         // Track inlined functions to remove later
         let mut inlined_functions = HashSet::new();
@@ -152,11 +145,7 @@ impl InliningAnalyzer {
                         modified_body.extend(inlined_stmts);
                         // Track which functions were inlined
                         if let HirStmt::Expr(HirExpr::Call { func: callee, .. }) = stmt {
-                            if decisions
-                                .get(callee)
-                                .map(|d| d.should_inline)
-                                .unwrap_or(false)
-                            {
+                            if decisions.get(callee).map(|d| d.should_inline).unwrap_or(false) {
                                 inlined_functions.insert(callee.clone());
                             }
                         }
@@ -172,11 +161,7 @@ impl InliningAnalyzer {
         if self.config.inline_single_use {
             program.functions.retain(|f| {
                 !inlined_functions.contains(&f.name)
-                    || self
-                        .function_metrics
-                        .get(&f.name)
-                        .map(|m| m.call_count > 1)
-                        .unwrap_or(true)
+                    || self.function_metrics.get(&f.name).map(|m| m.call_count > 1).unwrap_or(true)
             });
         }
 
@@ -187,16 +172,10 @@ impl InliningAnalyzer {
         for func in &program.functions {
             let calls = self.extract_calls_from_function(func);
 
-            self.call_graph
-                .calls
-                .insert(func.name.clone(), calls.clone());
+            self.call_graph.calls.insert(func.name.clone(), calls.clone());
 
             for callee in calls {
-                self.call_graph
-                    .called_by
-                    .entry(callee)
-                    .or_default()
-                    .insert(func.name.clone());
+                self.call_graph.called_by.entry(callee).or_default().insert(func.name.clone());
             }
         }
     }
@@ -216,17 +195,12 @@ impl InliningAnalyzer {
             HirStmt::Expr(expr) => self.extract_calls_from_expr(expr, calls),
             HirStmt::Assign { value, .. } => self.extract_calls_from_expr(value, calls),
             HirStmt::Return(Some(expr)) => self.extract_calls_from_expr(expr, calls),
-            HirStmt::If {
-                condition,
-                then_body,
-                else_body,
-            } => self.extract_calls_from_if(condition, then_body, else_body, calls),
-            HirStmt::While { condition, body }
-            | HirStmt::For {
-                iter: condition,
-                body,
-                ..
-            } => self.extract_calls_from_loop(condition, body, calls),
+            HirStmt::If { condition, then_body, else_body } => {
+                self.extract_calls_from_if(condition, then_body, else_body, calls)
+            }
+            HirStmt::While { condition, body } | HirStmt::For { iter: condition, body, .. } => {
+                self.extract_calls_from_loop(condition, body, calls)
+            }
             _ => {}
         }
     }
@@ -358,12 +332,8 @@ impl InliningAnalyzer {
             let return_count = self.count_returns(&func.body);
 
             // Calculate call count
-            let call_count = self
-                .call_graph
-                .called_by
-                .get(&func.name)
-                .map(|callers| callers.len())
-                .unwrap_or(0);
+            let call_count =
+                self.call_graph.called_by.get(&func.name).map(|callers| callers.len()).unwrap_or(0);
 
             // Estimate execution cost
             let cost = self.estimate_cost(func, size, has_loops, has_side_effects);
@@ -397,17 +367,12 @@ impl InliningAnalyzer {
             HirStmt::Assign { value, .. } => 1 + self.calculate_expr_size(value),
             HirStmt::Return(Some(expr)) => 1 + self.calculate_expr_size(expr),
             HirStmt::Return(None) => 1,
-            HirStmt::If {
-                condition,
-                then_body,
-                else_body,
-            } => self.calculate_if_size(condition, then_body, else_body),
-            HirStmt::While { condition, body }
-            | HirStmt::For {
-                iter: condition,
-                body,
-                ..
-            } => self.calculate_loop_size(condition, body),
+            HirStmt::If { condition, then_body, else_body } => {
+                self.calculate_if_size(condition, then_body, else_body)
+            }
+            HirStmt::While { condition, body } | HirStmt::For { iter: condition, body, .. } => {
+                self.calculate_loop_size(condition, body)
+            }
             _ => 1,
         }
     }
@@ -466,17 +431,12 @@ impl InliningAnalyzer {
             HirStmt::Expr(expr) => self.expr_has_side_effects(expr),
             HirStmt::Assign { value, .. } => self.expr_has_side_effects(value),
             HirStmt::Return(Some(expr)) => self.expr_has_side_effects(expr),
-            HirStmt::If {
-                condition,
-                then_body,
-                else_body,
-            } => self.if_has_side_effects(condition, then_body, else_body),
-            HirStmt::While { condition, body }
-            | HirStmt::For {
-                iter: condition,
-                body,
-                ..
-            } => self.loop_has_side_effects(condition, body),
+            HirStmt::If { condition, then_body, else_body } => {
+                self.if_has_side_effects(condition, then_body, else_body)
+            }
+            HirStmt::While { condition, body } | HirStmt::For { iter: condition, body, .. } => {
+                self.loop_has_side_effects(condition, body)
+            }
             HirStmt::Raise { .. } => true,
             _ => false,
         }
@@ -490,10 +450,7 @@ impl InliningAnalyzer {
     ) -> bool {
         self.expr_has_side_effects(condition)
             || self.body_has_side_effects(then_body)
-            || else_body
-                .as_ref()
-                .map(|stmts| self.body_has_side_effects(stmts))
-                .unwrap_or(false)
+            || else_body.as_ref().map(|stmts| self.body_has_side_effects(stmts)).unwrap_or(false)
     }
 
     fn loop_has_side_effects(&self, condition: &HirExpr, body: &[HirStmt]) -> bool {
@@ -756,7 +713,10 @@ impl InliningAnalyzer {
         for (i, param) in func.params.iter().enumerate() {
             if let Some(arg) = args.get(i) {
                 inlined_body.push(HirStmt::Assign {
-                    target: depyler_hir::hir::AssignTarget::Symbol(format!("_inline_{}", param.name)),
+                    target: depyler_hir::hir::AssignTarget::Symbol(format!(
+                        "_inline_{}",
+                        param.name
+                    )),
                     value: arg.clone(),
                     type_annotation: None,
                 });
@@ -788,11 +748,7 @@ impl InliningAnalyzer {
     ) -> HirStmt {
         match stmt {
             HirStmt::Expr(expr) => HirStmt::Expr(transform_expr_for_inlining_inner(expr, params)),
-            HirStmt::Assign {
-                target,
-                value,
-                type_annotation,
-            } => HirStmt::Assign {
+            HirStmt::Assign { target, value, type_annotation } => HirStmt::Assign {
                 target: self.transform_assign_target_for_inlining(target, params),
                 value: transform_expr_for_inlining_inner(value, params),
                 type_annotation: type_annotation.clone(),
@@ -800,11 +756,7 @@ impl InliningAnalyzer {
             HirStmt::Return(Some(expr)) => {
                 HirStmt::Return(Some(transform_expr_for_inlining_inner(expr, params)))
             }
-            HirStmt::If {
-                condition,
-                then_body,
-                else_body,
-            } => HirStmt::If {
+            HirStmt::If { condition, then_body, else_body } => HirStmt::If {
                 condition: transform_expr_for_inlining_inner(condition, params),
                 then_body: then_body
                     .iter()
@@ -873,11 +825,7 @@ fn contains_loops_inner(body: &[HirStmt]) -> bool {
     for stmt in body {
         match stmt {
             HirStmt::While { .. } | HirStmt::For { .. } => return true,
-            HirStmt::If {
-                then_body,
-                else_body,
-                ..
-            } => {
+            HirStmt::If { then_body, else_body, .. } => {
                 if contains_loops_inner(then_body) {
                     return true;
                 }
@@ -929,9 +877,7 @@ fn collection_has_side_effects(items: &[HirExpr]) -> bool {
 }
 
 fn dict_has_side_effects(pairs: &[(HirExpr, HirExpr)]) -> bool {
-    pairs
-        .iter()
-        .any(|(k, v)| expr_has_side_effects_inner(k) || expr_has_side_effects_inner(v))
+    pairs.iter().any(|(k, v)| expr_has_side_effects_inner(k) || expr_has_side_effects_inner(v))
 }
 
 fn count_returns_inner(body: &[HirStmt]) -> usize {
@@ -939,11 +885,7 @@ fn count_returns_inner(body: &[HirStmt]) -> usize {
     for stmt in body {
         match stmt {
             HirStmt::Return(_) => count += 1,
-            HirStmt::If {
-                then_body,
-                else_body,
-                ..
-            } => {
+            HirStmt::If { then_body, else_body, .. } => {
                 count += count_returns_inner(then_body);
                 if let Some(else_stmts) = else_body {
                     count += count_returns_inner(else_stmts);
@@ -958,7 +900,10 @@ fn count_returns_inner(body: &[HirStmt]) -> usize {
     count
 }
 
-fn transform_expr_for_inlining_inner(expr: &HirExpr, params: &[depyler_hir::hir::HirParam]) -> HirExpr {
+fn transform_expr_for_inlining_inner(
+    expr: &HirExpr,
+    params: &[depyler_hir::hir::HirParam],
+) -> HirExpr {
     match expr {
         HirExpr::Var(name) => {
             // Replace parameter references with inlined versions
@@ -979,10 +924,7 @@ fn transform_expr_for_inlining_inner(expr: &HirExpr, params: &[depyler_hir::hir:
         },
         HirExpr::Call { func, args, .. } => HirExpr::Call {
             func: func.clone(),
-            args: args
-                .iter()
-                .map(|a| transform_expr_for_inlining_inner(a, params))
-                .collect(),
+            args: args.iter().map(|a| transform_expr_for_inlining_inner(a, params)).collect(),
             kwargs: vec![],
         },
         _ => expr.clone(),
@@ -1356,16 +1298,8 @@ mod tests {
     fn test_extract_calls_from_list() {
         let mut calls = HashSet::new();
         let expr = HirExpr::List(vec![
-            HirExpr::Call {
-                func: "fn1".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            },
-            HirExpr::Call {
-                func: "fn2".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            },
+            HirExpr::Call { func: "fn1".to_string(), args: vec![], kwargs: vec![] },
+            HirExpr::Call { func: "fn2".to_string(), args: vec![], kwargs: vec![] },
         ]);
         extract_calls_from_expr_inner(&expr, &mut calls);
         assert!(calls.contains("fn1"));
@@ -1388,16 +1322,8 @@ mod tests {
     fn test_extract_calls_from_dict() {
         let mut calls = HashSet::new();
         let expr = HirExpr::Dict(vec![(
-            HirExpr::Call {
-                func: "key_fn".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            },
-            HirExpr::Call {
-                func: "val_fn".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            },
+            HirExpr::Call { func: "key_fn".to_string(), args: vec![], kwargs: vec![] },
+            HirExpr::Call { func: "val_fn".to_string(), args: vec![], kwargs: vec![] },
         )]);
         extract_calls_from_expr_inner(&expr, &mut calls);
         assert!(calls.contains("key_fn"));
@@ -1414,11 +1340,7 @@ mod tests {
                 kwargs: vec![],
             }),
             method: "method".to_string(),
-            args: vec![HirExpr::Call {
-                func: "get_arg".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            }],
+            args: vec![HirExpr::Call { func: "get_arg".to_string(), args: vec![], kwargs: vec![] }],
             kwargs: vec![],
         };
         extract_calls_from_expr_inner(&expr, &mut calls);
@@ -1566,11 +1488,7 @@ mod tests {
             ret_type: Type::Int,
             body: vec![HirStmt::For {
                 target: AssignTarget::Symbol("i".to_string()),
-                iter: HirExpr::Call {
-                    func: "for_iter".to_string(),
-                    args: vec![],
-                    kwargs: vec![],
-                },
+                iter: HirExpr::Call { func: "for_iter".to_string(), args: vec![], kwargs: vec![] },
                 body: vec![HirStmt::Expr(HirExpr::Call {
                     func: "for_body".to_string(),
                     args: vec![],
@@ -1609,10 +1527,7 @@ mod tests {
     fn test_expr_size_call() {
         let expr = HirExpr::Call {
             func: "fn".to_string(),
-            args: vec![
-                HirExpr::Literal(Literal::Int(1)),
-                HirExpr::Literal(Literal::Int(2)),
-            ],
+            args: vec![HirExpr::Literal(Literal::Int(1)), HirExpr::Literal(Literal::Int(2))],
             kwargs: vec![],
         };
         let size = calculate_expr_size_inner(&expr);
@@ -1634,14 +1549,8 @@ mod tests {
     #[test]
     fn test_expr_size_dict() {
         let expr = HirExpr::Dict(vec![
-            (
-                HirExpr::Literal(Literal::String("a".to_string())),
-                HirExpr::Literal(Literal::Int(1)),
-            ),
-            (
-                HirExpr::Literal(Literal::String("b".to_string())),
-                HirExpr::Literal(Literal::Int(2)),
-            ),
+            (HirExpr::Literal(Literal::String("a".to_string())), HirExpr::Literal(Literal::Int(1))),
+            (HirExpr::Literal(Literal::String("b".to_string())), HirExpr::Literal(Literal::Int(2))),
         ]);
         let size = calculate_expr_size_inner(&expr);
         assert!(size >= 5); // 2 pairs * 2 elements + 1 base
@@ -1725,10 +1634,7 @@ mod tests {
         let expr = HirExpr::MethodCall {
             object: Box::new(HirExpr::Var("list".to_string())),
             method: "insert".to_string(),
-            args: vec![
-                HirExpr::Literal(Literal::Int(0)),
-                HirExpr::Literal(Literal::Int(42)),
-            ],
+            args: vec![HirExpr::Literal(Literal::Int(0)), HirExpr::Literal(Literal::Int(42))],
             kwargs: vec![],
         };
         assert!(expr_has_side_effects_inner(&expr));
@@ -1793,11 +1699,7 @@ mod tests {
     fn test_side_effect_in_args() {
         let expr = HirExpr::Call {
             func: "pure_fn".to_string(),
-            args: vec![HirExpr::Call {
-                func: "print".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            }],
+            args: vec![HirExpr::Call { func: "print".to_string(), args: vec![], kwargs: vec![] }],
             kwargs: vec![],
         };
         assert!(expr_has_side_effects_inner(&expr));
@@ -1992,10 +1894,7 @@ mod tests {
     fn test_expr_size_call_with_args() {
         let expr = HirExpr::Call {
             func: "func".to_string(),
-            args: vec![
-                HirExpr::Literal(Literal::Int(1)),
-                HirExpr::Literal(Literal::Int(2)),
-            ],
+            args: vec![HirExpr::Literal(Literal::Int(1)), HirExpr::Literal(Literal::Int(2))],
             kwargs: vec![],
         };
         let size = calculate_expr_size_inner(&expr);
@@ -2077,9 +1976,7 @@ mod tests {
         let body = vec![HirStmt::If {
             condition: HirExpr::Literal(Literal::Bool(true)),
             then_body: vec![HirStmt::Return(Some(HirExpr::Literal(Literal::Int(1))))],
-            else_body: Some(vec![HirStmt::Return(Some(HirExpr::Literal(Literal::Int(
-                2,
-            ))))]),
+            else_body: Some(vec![HirStmt::Return(Some(HirExpr::Literal(Literal::Int(2))))]),
         }];
         let count = count_returns_inner(&body);
         assert_eq!(count, 2);
@@ -2197,11 +2094,7 @@ mod tests {
     fn test_extract_calls_from_nested_call() {
         let expr = HirExpr::Call {
             func: "outer".to_string(),
-            args: vec![HirExpr::Call {
-                func: "inner".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            }],
+            args: vec![HirExpr::Call { func: "inner".to_string(), args: vec![], kwargs: vec![] }],
             kwargs: vec![],
         };
         let mut calls = std::collections::HashSet::new();
@@ -2279,9 +2172,7 @@ mod tests {
         let stmt = HirStmt::If {
             condition: HirExpr::Literal(Literal::Bool(true)),
             then_body: vec![HirStmt::Return(Some(HirExpr::Literal(Literal::Int(1))))],
-            else_body: Some(vec![HirStmt::Return(Some(HirExpr::Literal(Literal::Int(
-                2,
-            ))))]),
+            else_body: Some(vec![HirStmt::Return(Some(HirExpr::Literal(Literal::Int(2))))]),
         };
         let size = analyzer.calculate_stmt_size(&stmt);
         assert!(size >= 3);
@@ -2329,11 +2220,7 @@ mod tests {
         let analyzer = InliningAnalyzer::new(InliningConfig::default());
         let stmt = HirStmt::Assign {
             target: AssignTarget::Symbol("x".to_string()),
-            value: HirExpr::Call {
-                func: "print".to_string(),
-                args: vec![],
-                kwargs: vec![],
-            },
+            value: HirExpr::Call { func: "print".to_string(), args: vec![], kwargs: vec![] },
             type_annotation: None,
         };
         assert!(analyzer.stmt_has_side_effects(&stmt));
@@ -2356,37 +2243,25 @@ mod tests {
     // --- Config variations ---
     #[test]
     fn test_config_no_inline_single_use() {
-        let config = InliningConfig {
-            inline_single_use: false,
-            ..Default::default()
-        };
+        let config = InliningConfig { inline_single_use: false, ..Default::default() };
         assert!(!config.inline_single_use);
     }
 
     #[test]
     fn test_config_no_inline_trivial() {
-        let config = InliningConfig {
-            inline_trivial: false,
-            ..Default::default()
-        };
+        let config = InliningConfig { inline_trivial: false, ..Default::default() };
         assert!(!config.inline_trivial);
     }
 
     #[test]
     fn test_config_inline_loops() {
-        let config = InliningConfig {
-            inline_loops: true,
-            ..Default::default()
-        };
+        let config = InliningConfig { inline_loops: true, ..Default::default() };
         assert!(config.inline_loops);
     }
 
     #[test]
     fn test_config_high_cost_threshold() {
-        let config = InliningConfig {
-            cost_threshold: 10.0,
-            ..Default::default()
-        };
+        let config = InliningConfig { cost_threshold: 10.0, ..Default::default() };
         assert_eq!(config.cost_threshold, 10.0);
     }
 

--- a/crates/depyler-analysis/src/optimizer.rs
+++ b/crates/depyler-analysis/src/optimizer.rs
@@ -97,11 +97,7 @@ impl Optimizer {
 
         for stmt in body {
             match stmt {
-                HirStmt::If {
-                    condition,
-                    then_body,
-                    else_body,
-                } => {
+                HirStmt::If { condition, then_body, else_body } => {
                     // Extract walrus operators from condition
                     let (walrus_assigns, simplified_condition) =
                         self.extract_walrus_from_expr(condition);
@@ -117,9 +113,7 @@ impl Optimizer {
 
                     // Recursively process then/else bodies
                     let new_then = self.hoist_walrus_in_body(then_body);
-                    let new_else = else_body
-                        .as_ref()
-                        .map(|stmts| self.hoist_walrus_in_body(stmts));
+                    let new_else = else_body.as_ref().map(|stmts| self.hoist_walrus_in_body(stmts));
 
                     new_body.push(HirStmt::If {
                         condition: simplified_condition,
@@ -127,10 +121,7 @@ impl Optimizer {
                         else_body: new_else,
                     });
                 }
-                HirStmt::While {
-                    condition,
-                    body: while_body,
-                } => {
+                HirStmt::While { condition, body: while_body } => {
                     // Extract walrus from while condition
                     let (walrus_assigns, simplified_condition) =
                         self.extract_walrus_from_expr(condition);
@@ -150,11 +141,7 @@ impl Optimizer {
                         body: new_while_body,
                     });
                 }
-                HirStmt::For {
-                    target,
-                    iter,
-                    body: for_body,
-                } => {
+                HirStmt::For { target, iter, body: for_body } => {
                     // Recursively process for body
                     let new_for_body = self.hoist_walrus_in_body(for_body);
                     new_body.push(HirStmt::For {
@@ -163,12 +150,7 @@ impl Optimizer {
                         body: new_for_body,
                     });
                 }
-                HirStmt::Try {
-                    body: try_body,
-                    handlers,
-                    orelse,
-                    finalbody,
-                } => {
+                HirStmt::Try { body: try_body, handlers, orelse, finalbody } => {
                     // Recursively process try/except blocks
                     let new_try_body = self.hoist_walrus_in_body(try_body);
                     let new_handlers: Vec<_> = handlers
@@ -179,12 +161,9 @@ impl Optimizer {
                             body: self.hoist_walrus_in_body(&h.body),
                         })
                         .collect();
-                    let new_orelse = orelse
-                        .as_ref()
-                        .map(|stmts| self.hoist_walrus_in_body(stmts));
-                    let new_finalbody = finalbody
-                        .as_ref()
-                        .map(|stmts| self.hoist_walrus_in_body(stmts));
+                    let new_orelse = orelse.as_ref().map(|stmts| self.hoist_walrus_in_body(stmts));
+                    let new_finalbody =
+                        finalbody.as_ref().map(|stmts| self.hoist_walrus_in_body(stmts));
                     new_body.push(HirStmt::Try {
                         body: new_try_body,
                         handlers: new_handlers,
@@ -192,12 +171,7 @@ impl Optimizer {
                         finalbody: new_finalbody,
                     });
                 }
-                HirStmt::With {
-                    context,
-                    target,
-                    body: with_body,
-                    is_async,
-                } => {
+                HirStmt::With { context, target, body: with_body, is_async } => {
                     let new_with_body = self.hoist_walrus_in_body(with_body);
                     new_body.push(HirStmt::With {
                         context: context.clone(),
@@ -245,27 +219,16 @@ impl Optimizer {
             },
             HirExpr::Call { func, args, kwargs } => HirExpr::Call {
                 func: func.clone(),
-                args: args
-                    .iter()
-                    .map(|a| self.extract_walrus_recursive(a, assigns))
-                    .collect(),
+                args: args.iter().map(|a| self.extract_walrus_recursive(a, assigns)).collect(),
                 kwargs: kwargs
                     .iter()
                     .map(|(k, v)| (k.clone(), self.extract_walrus_recursive(v, assigns)))
                     .collect(),
             },
-            HirExpr::MethodCall {
-                object,
-                method,
-                args,
-                kwargs,
-            } => HirExpr::MethodCall {
+            HirExpr::MethodCall { object, method, args, kwargs } => HirExpr::MethodCall {
                 object: Box::new(self.extract_walrus_recursive(object, assigns)),
                 method: method.clone(),
-                args: args
-                    .iter()
-                    .map(|a| self.extract_walrus_recursive(a, assigns))
-                    .collect(),
+                args: args.iter().map(|a| self.extract_walrus_recursive(a, assigns)).collect(),
                 kwargs: kwargs
                     .iter()
                     .map(|(k, v)| (k.clone(), self.extract_walrus_recursive(v, assigns)))
@@ -344,11 +307,7 @@ impl Optimizer {
             HirStmt::Expr(expr) => {
                 Self::collect_read_vars_expr(expr, read_vars);
             }
-            HirStmt::If {
-                condition,
-                then_body,
-                else_body,
-            } => {
+            HirStmt::If { condition, then_body, else_body } => {
                 Self::collect_read_vars_expr(condition, read_vars);
                 for s in then_body {
                     Self::collect_read_vars_stmt(s, read_vars);
@@ -433,17 +392,10 @@ impl Optimizer {
         assignments: &mut HashMap<String, usize>,
     ) {
         match stmt {
-            HirStmt::Assign {
-                target: AssignTarget::Symbol(name),
-                ..
-            } => {
+            HirStmt::Assign { target: AssignTarget::Symbol(name), .. } => {
                 *assignments.entry(name.clone()).or_insert(0) += 1;
             }
-            HirStmt::If {
-                then_body,
-                else_body,
-                ..
-            } => {
+            HirStmt::If { then_body, else_body, .. } => {
                 self.count_assignments_stmt(then_body, assignments);
                 if let Some(else_stmts) = else_body {
                     self.count_assignments_stmt(else_stmts, assignments);
@@ -476,11 +428,7 @@ impl Optimizer {
         used_vars: &HashSet<String>,
     ) {
         match stmt {
-            HirStmt::Assign {
-                target: AssignTarget::Symbol(name),
-                value,
-                ..
-            } => {
+            HirStmt::Assign { target: AssignTarget::Symbol(name), value, .. } => {
                 // DEPYLER-0269 Fix: Only propagate constants for dead code
                 // Skip variables that are:
                 // 1. Mutated (assigned more than once) - already checked
@@ -494,11 +442,7 @@ impl Optimizer {
                 }
             }
             HirStmt::Assign { .. } => {}
-            HirStmt::If {
-                then_body,
-                else_body,
-                ..
-            } => {
+            HirStmt::If { then_body, else_body, .. } => {
                 for s in then_body {
                     self.collect_constants_stmt(s, constants, mutated_vars, used_vars);
                 }
@@ -539,11 +483,7 @@ impl Optimizer {
             HirStmt::Return(Some(expr)) => {
                 self.propagate_constants_expr(expr, constants);
             }
-            HirStmt::If {
-                condition,
-                then_body,
-                else_body,
-            } => {
+            HirStmt::If { condition, then_body, else_body } => {
                 self.propagate_constants_expr(condition, constants);
                 for s in then_body {
                     self.propagate_constants_stmt(s, constants);
@@ -739,11 +679,7 @@ impl Optimizer {
 
             // Remove truly dead assignments (not used and no side effects)
             func.body.retain(|stmt| {
-                if let HirStmt::Assign {
-                    target: AssignTarget::Symbol(name),
-                    ..
-                } = stmt
-                {
+                if let HirStmt::Assign { target: AssignTarget::Symbol(name), .. } = stmt {
                     // Keep if: truly used OR has side effects
                     // DEPYLER-0934: Removed .trim_start_matches('_') since we no longer rename
                     used_vars.contains_key(name) || side_effect_vars.contains(name)
@@ -775,11 +711,7 @@ impl Optimizer {
             HirStmt::Return(Some(expr)) => {
                 self.collect_used_vars_expr(expr, used);
             }
-            HirStmt::If {
-                condition,
-                then_body,
-                else_body,
-            } => {
+            HirStmt::If { condition, then_body, else_body } => {
                 self.collect_used_vars_expr(condition, used);
                 for s in then_body {
                     self.collect_truly_used_vars_stmt(s, used);
@@ -806,12 +738,7 @@ impl Optimizer {
                 self.collect_used_vars_expr(expr, used);
             }
             // DEPYLER-0514: Handle Try statements - recurse into all blocks
-            HirStmt::Try {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-            } => {
+            HirStmt::Try { body, handlers, orelse, finalbody } => {
                 // Recurse into try body
                 for s in body {
                     self.collect_truly_used_vars_stmt(s, used);
@@ -908,22 +835,11 @@ impl Optimizer {
                 .any(|(k, v)| Self::expr_has_side_effects(k) || Self::expr_has_side_effects(v)),
             HirExpr::Set(items) => items.iter().any(Self::expr_has_side_effects),
             HirExpr::Attribute { value, .. } => Self::expr_has_side_effects(value),
-            HirExpr::Slice {
-                base,
-                start,
-                stop,
-                step,
-            } => {
+            HirExpr::Slice { base, start, stop, step } => {
                 Self::expr_has_side_effects(base)
-                    || start
-                        .as_ref()
-                        .is_some_and(|e| Self::expr_has_side_effects(e))
-                    || stop
-                        .as_ref()
-                        .is_some_and(|e| Self::expr_has_side_effects(e))
-                    || step
-                        .as_ref()
-                        .is_some_and(|e| Self::expr_has_side_effects(e))
+                    || start.as_ref().is_some_and(|e| Self::expr_has_side_effects(e))
+                    || stop.as_ref().is_some_and(|e| Self::expr_has_side_effects(e))
+                    || step.as_ref().is_some_and(|e| Self::expr_has_side_effects(e))
             }
             _ => false,
         }
@@ -1018,11 +934,7 @@ impl Optimizer {
             let is_final_stmt = idx == body.len() - 1;
 
             match stmt {
-                HirStmt::Assign {
-                    target,
-                    value,
-                    type_annotation,
-                } => {
+                HirStmt::Assign { target, value, type_annotation } => {
                     let (new_value, extra_stmts) =
                         self.process_expr_for_cse(value, cse_map, temp_counter);
                     new_body.extend(extra_stmts);
@@ -1045,11 +957,7 @@ impl Optimizer {
                         new_body.push(HirStmt::Return(Some(new_expr)));
                     }
                 }
-                HirStmt::If {
-                    condition,
-                    then_body,
-                    else_body,
-                } => {
+                HirStmt::If { condition, then_body, else_body } => {
                     let (new_condition, extra_stmts) =
                         self.process_expr_for_cse(condition, cse_map, temp_counter);
                     new_body.extend(extra_stmts);
@@ -1136,11 +1044,7 @@ impl Optimizer {
                     new_args.push(new_arg);
                 }
 
-                let new_expr = HirExpr::Call {
-                    func: func.clone(),
-                    args: new_args,
-                    kwargs: vec![],
-                };
+                let new_expr = HirExpr::Call { func: func.clone(), args: new_args, kwargs: vec![] };
 
                 let hash = self.hash_expr(&new_expr);
 
@@ -1308,12 +1212,7 @@ fn collect_used_vars_expr_inner(expr: &HirExpr, used: &mut HashMap<String, bool>
                 collect_used_vars_expr_inner(v, used);
             }
         }
-        HirExpr::MethodCall {
-            object,
-            args,
-            kwargs,
-            ..
-        } => {
+        HirExpr::MethodCall { object, args, kwargs, .. } => {
             collect_used_vars_expr_inner(object, used);
             for arg in args {
                 collect_used_vars_expr_inner(arg, used);
@@ -1326,10 +1225,7 @@ fn collect_used_vars_expr_inner(expr: &HirExpr, used: &mut HashMap<String, bool>
         HirExpr::Lambda { body, .. } => {
             collect_used_vars_expr_inner(body, used);
         }
-        HirExpr::ListComp {
-            element,
-            generators,
-        } => {
+        HirExpr::ListComp { element, generators } => {
             // DEPYLER-0504: Support multiple generators
             collect_used_vars_expr_inner(element, used);
             for gen in generators {
@@ -1339,10 +1235,7 @@ fn collect_used_vars_expr_inner(expr: &HirExpr, used: &mut HashMap<String, bool>
                 }
             }
         }
-        HirExpr::SetComp {
-            element,
-            generators,
-        } => {
+        HirExpr::SetComp { element, generators } => {
             // DEPYLER-0504: Support multiple generators
             collect_used_vars_expr_inner(element, used);
             for gen in generators {
@@ -1355,11 +1248,7 @@ fn collect_used_vars_expr_inner(expr: &HirExpr, used: &mut HashMap<String, bool>
         // DEPYLER-0600 #5: DictComp was missing from DCE analysis
         // This caused variables used only in dict comprehension iterators to be
         // incorrectly removed. Example: `d = {str(n): n*n for n in nums}` lost `nums`
-        HirExpr::DictComp {
-            key,
-            value,
-            generators,
-        } => {
+        HirExpr::DictComp { key, value, generators } => {
             // Collect used vars from key and value expressions
             collect_used_vars_expr_inner(key, used);
             collect_used_vars_expr_inner(value, used);
@@ -1374,12 +1263,7 @@ fn collect_used_vars_expr_inner(expr: &HirExpr, used: &mut HashMap<String, bool>
         HirExpr::Await { value } => {
             collect_used_vars_expr_inner(value, used);
         }
-        HirExpr::Slice {
-            base,
-            start,
-            stop,
-            step,
-        } => {
+        HirExpr::Slice { base, start, stop, step } => {
             // DEPYLER-0209 FIX: Collect variables from slice expressions
             // This was causing dead code elimination to remove assignments
             // for variables used in slice operations like: numbers[2:7]
@@ -1429,12 +1313,7 @@ fn collect_used_vars_expr_inner(expr: &HirExpr, used: &mut HashMap<String, bool>
         // DEPYLER-0935: Collect variables from SortByKey expression
         // sorted(data, key=lambda r: r[0]) is converted to HirExpr::SortByKey
         // We must collect variables from iterable, key_body, and reverse_expr
-        HirExpr::SortByKey {
-            iterable,
-            key_body,
-            reverse_expr,
-            ..
-        } => {
+        HirExpr::SortByKey { iterable, key_body, reverse_expr, .. } => {
             collect_used_vars_expr_inner(iterable, used);
             collect_used_vars_expr_inner(key_body, used);
             if let Some(rev) = reverse_expr {
@@ -1448,10 +1327,10 @@ fn collect_used_vars_expr_inner(expr: &HirExpr, used: &mut HashMap<String, bool>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use depyler_annotations::TranspilationAnnotations;
     use depyler_hir::hir::{
         AssignTarget, FunctionProperties, HirExpr, HirFunction, HirProgram, HirStmt, Literal, Type,
     };
-    use depyler_annotations::TranspilationAnnotations;
     use smallvec::smallvec;
 
     #[test]
@@ -1557,10 +1436,7 @@ mod tests {
     #[test]
     fn test_dead_code_elimination_when_enabled() {
         // Test what happens when dead code elimination IS explicitly enabled
-        let config = OptimizerConfig {
-            eliminate_dead_code: true,
-            ..Default::default()
-        };
+        let config = OptimizerConfig { eliminate_dead_code: true, ..Default::default() };
         let mut optimizer = Optimizer::new(config);
 
         let program = HirProgram {
@@ -1595,16 +1471,10 @@ mod tests {
 
         // When enabled, unused assignment should be removed
         // "used" assignment is kept because it's read in return
-        assert!(
-            func.body.len() <= 3,
-            "Dead code elimination should remove or preserve statements"
-        );
+        assert!(func.body.len() <= 3, "Dead code elimination should remove or preserve statements");
 
         // At minimum, the return statement should exist
-        let has_return = func
-            .body
-            .iter()
-            .any(|stmt| matches!(stmt, HirStmt::Return(_)));
+        let has_return = func.body.iter().any(|stmt| matches!(stmt, HirStmt::Return(_)));
         assert!(has_return, "Return statement should be preserved");
     }
 
@@ -1664,19 +1534,12 @@ mod tests {
 
         // Verify the unused variable was removed, not just renamed
         let has_unused = func.body.iter().any(|stmt| {
-            if let HirStmt::Assign {
-                target: AssignTarget::Symbol(name),
-                ..
-            } = stmt
-            {
+            if let HirStmt::Assign { target: AssignTarget::Symbol(name), .. } = stmt {
                 return name == "unused" || name == "_unused";
             }
             false
         });
-        assert!(
-            !has_unused,
-            "DEPYLER-0508: 'unused' variable should be completely eliminated"
-        );
+        assert!(!has_unused, "DEPYLER-0508: 'unused' variable should be completely eliminated");
     }
 
     // ==========================================================================
@@ -1892,11 +1755,7 @@ mod tests {
     #[test]
     fn test_expr_has_side_effects_call() {
         // Function calls have side effects
-        let expr = HirExpr::Call {
-            func: "print".to_string(),
-            args: vec![],
-            kwargs: vec![],
-        };
+        let expr = HirExpr::Call { func: "print".to_string(), args: vec![], kwargs: vec![] };
         assert!(Optimizer::expr_has_side_effects(&expr));
     }
 
@@ -2144,15 +2003,9 @@ mod tests {
     #[test]
     fn test_is_constant_expr_inner_literals() {
         assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::Int(42))));
-        assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::Float(
-            3.15
-        ))));
-        assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::Bool(
-            true
-        ))));
-        assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::String(
-            "hi".into()
-        ))));
+        assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::Float(3.15))));
+        assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::Bool(true))));
+        assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::String("hi".into()))));
         assert!(is_constant_expr_inner(&HirExpr::Literal(Literal::None)));
     }
 
@@ -2182,11 +2035,7 @@ mod tests {
     #[test]
     fn test_optimizer_with_empty_program() {
         let mut optimizer = Optimizer::new(OptimizerConfig::default());
-        let program = HirProgram {
-            functions: vec![],
-            classes: vec![],
-            imports: vec![],
-        };
+        let program = HirProgram { functions: vec![], classes: vec![], imports: vec![] };
         let result = optimizer.optimize_program(program);
         assert!(result.functions.is_empty());
     }
@@ -2236,10 +2085,8 @@ mod tests {
     #[test]
     fn test_evaluate_constant_unaryop_non_constant() {
         let optimizer = Optimizer::new(OptimizerConfig::default());
-        let expr = HirExpr::Unary {
-            op: UnaryOp::Not,
-            operand: Box::new(HirExpr::Var("x".to_string())),
-        };
+        let expr =
+            HirExpr::Unary { op: UnaryOp::Not, operand: Box::new(HirExpr::Var("x".to_string())) };
         let result = optimizer.evaluate_constant_unaryop(&expr);
         assert!(result.is_none());
     }
@@ -2345,10 +2192,8 @@ mod tests {
     #[test]
     fn test_collect_used_vars_tuple() {
         let mut used = HashMap::new();
-        let expr = HirExpr::Tuple(vec![
-            HirExpr::Var("a".to_string()),
-            HirExpr::Var("b".to_string()),
-        ]);
+        let expr =
+            HirExpr::Tuple(vec![HirExpr::Var("a".to_string()), HirExpr::Var("b".to_string())]);
         collect_used_vars_expr_inner(&expr, &mut used);
         assert!(used.contains_key("a"));
         assert!(used.contains_key("b"));
@@ -2357,10 +2202,8 @@ mod tests {
     #[test]
     fn test_collect_used_vars_list() {
         let mut used = HashMap::new();
-        let expr = HirExpr::List(vec![
-            HirExpr::Var("x".to_string()),
-            HirExpr::Var("y".to_string()),
-        ]);
+        let expr =
+            HirExpr::List(vec![HirExpr::Var("x".to_string()), HirExpr::Var("y".to_string())]);
         collect_used_vars_expr_inner(&expr, &mut used);
         assert!(used.contains_key("x"));
         assert!(used.contains_key("y"));
@@ -2369,10 +2212,8 @@ mod tests {
     #[test]
     fn test_collect_used_vars_dict() {
         let mut used = HashMap::new();
-        let expr = HirExpr::Dict(vec![(
-            HirExpr::Var("key".to_string()),
-            HirExpr::Var("val".to_string()),
-        )]);
+        let expr =
+            HirExpr::Dict(vec![(HirExpr::Var("key".to_string()), HirExpr::Var("val".to_string()))]);
         collect_used_vars_expr_inner(&expr, &mut used);
         assert!(used.contains_key("key"));
         assert!(used.contains_key("val"));
@@ -2499,9 +2340,7 @@ mod tests {
     #[test]
     fn test_collect_used_vars_await() {
         let mut used = HashMap::new();
-        let expr = HirExpr::Await {
-            value: Box::new(HirExpr::Var("future".to_string())),
-        };
+        let expr = HirExpr::Await { value: Box::new(HirExpr::Var("future".to_string())) };
         collect_used_vars_expr_inner(&expr, &mut used);
         assert!(used.contains_key("future"));
     }
@@ -2678,16 +2517,8 @@ mod tests {
 
     #[test]
     fn test_hash_expr_call_different_func() {
-        let expr1 = HirExpr::Call {
-            func: "len".to_string(),
-            args: vec![],
-            kwargs: vec![],
-        };
-        let expr2 = HirExpr::Call {
-            func: "abs".to_string(),
-            args: vec![],
-            kwargs: vec![],
-        };
+        let expr1 = HirExpr::Call { func: "len".to_string(), args: vec![], kwargs: vec![] };
+        let expr2 = HirExpr::Call { func: "abs".to_string(), args: vec![], kwargs: vec![] };
         let optimizer = Optimizer::new(OptimizerConfig::default());
         assert_ne!(optimizer.hash_expr(&expr1), optimizer.hash_expr(&expr2));
     }
@@ -2796,10 +2627,7 @@ mod tests {
 
     #[test]
     fn test_eliminate_dead_code_preserves_side_effects() {
-        let config = OptimizerConfig {
-            eliminate_dead_code: true,
-            ..Default::default()
-        };
+        let config = OptimizerConfig { eliminate_dead_code: true, ..Default::default() };
         let mut optimizer = Optimizer::new(config);
 
         let program = HirProgram {
@@ -2827,10 +2655,7 @@ mod tests {
 
         // print() has side effects, should be preserved
         let func = &optimized.functions[0];
-        assert!(
-            !func.body.is_empty(),
-            "Side effect statement should be preserved"
-        );
+        assert!(!func.body.is_empty(), "Side effect statement should be preserved");
     }
 
     // === Additional tests for expr_has_side_effects ===
@@ -3009,11 +2834,7 @@ mod tests {
         // Both should behave identically
         let mut opt1 = Optimizer::new(config);
         let mut opt2 = Optimizer::new(cloned);
-        let program = HirProgram {
-            functions: vec![],
-            classes: vec![],
-            imports: vec![],
-        };
+        let program = HirProgram { functions: vec![], classes: vec![], imports: vec![] };
         let result1 = opt1.optimize_program(program.clone());
         let result2 = opt2.optimize_program(program);
         assert_eq!(result1.functions.len(), result2.functions.len());

--- a/crates/depyler-analysis/src/param_type_inference.rs
+++ b/crates/depyler-analysis/src/param_type_inference.rs
@@ -16,12 +16,7 @@ use depyler_hir::hir::{
 pub fn infer_param_type_from_body(param_name: &str, body: &[HirStmt]) -> Option<Type> {
     for stmt in body {
         // Pattern 1: Tuple unpacking - `a, b, c = param`
-        if let HirStmt::Assign {
-            target,
-            value: HirExpr::Var(var),
-            type_annotation: _,
-        } = stmt
-        {
+        if let HirStmt::Assign { target, value: HirExpr::Var(var), type_annotation: _ } = stmt {
             if var == param_name {
                 if let AssignTarget::Tuple(elements) = target {
                     let elem_types = vec![Type::String; elements.len()];
@@ -52,12 +47,7 @@ pub fn infer_param_type_from_body(param_name: &str, body: &[HirStmt]) -> Option<
         }
 
         // Pattern 4: If statement - check condition and body
-        if let HirStmt::If {
-            condition,
-            then_body,
-            else_body,
-        } = stmt
-        {
+        if let HirStmt::If { condition, then_body, else_body } = stmt {
             if let Some(ty) = infer_type_from_expr_usage(param_name, condition) {
                 return Some(ty);
             }
@@ -86,10 +76,7 @@ pub fn infer_param_type_from_body(param_name: &str, body: &[HirStmt]) -> Option<
         }
 
         // Pattern 7: While loop - check condition and body
-        if let HirStmt::While {
-            condition, body, ..
-        } = stmt
-        {
+        if let HirStmt::While { condition, body, .. } = stmt {
             if let Some(ty) = infer_type_from_expr_usage(param_name, condition) {
                 return Some(ty);
             }
@@ -99,13 +86,7 @@ pub fn infer_param_type_from_body(param_name: &str, body: &[HirStmt]) -> Option<
         }
 
         // Pattern 8: Try/except - check all bodies
-        if let HirStmt::Try {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-        } = stmt
-        {
+        if let HirStmt::Try { body, handlers, orelse, finalbody } = stmt {
             if let Some(ty) = infer_param_type_from_body(param_name, body) {
                 return Some(ty);
             }
@@ -131,28 +112,25 @@ pub fn infer_param_type_from_body(param_name: &str, body: &[HirStmt]) -> Option<
 
 fn infer_type_from_expr_usage(param_name: &str, expr: &HirExpr) -> Option<Type> {
     match expr {
-        HirExpr::Call { func, args, kwargs } => infer_from_call_expr(param_name, func, args, kwargs),
-        HirExpr::MethodCall {
-            object,
-            method,
-            args,
-            kwargs,
-        } => infer_from_method_call(param_name, object, method, args, kwargs),
+        HirExpr::Call { func, args, kwargs } => {
+            infer_from_call_expr(param_name, func, args, kwargs)
+        }
+        HirExpr::MethodCall { object, method, args, kwargs } => {
+            infer_from_method_call(param_name, object, method, args, kwargs)
+        }
         HirExpr::FString { parts } => infer_from_fstring(param_name, parts),
         HirExpr::Index { base, index } => infer_from_index_expr(param_name, base, index),
         HirExpr::Slice { base, .. } => infer_from_slice_expr(param_name, base),
-        HirExpr::Binary {
-            left, right, op, ..
-        } => infer_from_binary_expr(param_name, op, left, right),
+        HirExpr::Binary { left, right, op, .. } => {
+            infer_from_binary_expr(param_name, op, left, right)
+        }
         HirExpr::Unary { operand, .. } => infer_type_from_expr_usage(param_name, operand),
-        HirExpr::ListComp {
-            element,
-            generators,
-        } => infer_from_list_comp(param_name, element, generators),
-        HirExpr::GeneratorExp {
-            element,
-            generators,
-        } => infer_from_generator_exp(param_name, element, generators),
+        HirExpr::ListComp { element, generators } => {
+            infer_from_list_comp(param_name, element, generators)
+        }
+        HirExpr::GeneratorExp { element, generators } => {
+            infer_from_generator_exp(param_name, element, generators)
+        }
         _ => None,
     }
 }
@@ -248,11 +226,7 @@ fn infer_from_method_call(
     infer_type_from_expr_usage(param_name, object)
 }
 
-fn infer_from_object_method(
-    param_name: &str,
-    object: &HirExpr,
-    method: &str,
-) -> Option<Type> {
+fn infer_from_object_method(param_name: &str, object: &HirExpr, method: &str) -> Option<Type> {
     let HirExpr::Var(var_name) = object else {
         return None;
     };
@@ -261,28 +235,73 @@ fn infer_from_object_method(
     }
 
     const FILE_METHODS: &[&str] = &[
-        "write", "writelines", "read", "readline", "readlines",
-        "flush", "close", "seek", "tell", "truncate",
+        "write",
+        "writelines",
+        "read",
+        "readline",
+        "readlines",
+        "flush",
+        "close",
+        "seek",
+        "tell",
+        "truncate",
     ];
     if FILE_METHODS.contains(&method) {
         return Some(Type::Custom("File".to_string()));
     }
 
     const STRING_METHODS: &[&str] = &[
-        "strip", "lstrip", "rstrip", "startswith", "endswith", "split",
-        "splitlines", "join", "upper", "lower", "title", "capitalize",
-        "replace", "find", "rfind", "index", "rindex", "count",
-        "isalpha", "isdigit", "isalnum", "isspace", "isupper", "islower",
-        "encode", "format", "center", "ljust", "rjust", "zfill",
-        "partition", "rpartition", "expandtabs", "swapcase", "casefold",
+        "strip",
+        "lstrip",
+        "rstrip",
+        "startswith",
+        "endswith",
+        "split",
+        "splitlines",
+        "join",
+        "upper",
+        "lower",
+        "title",
+        "capitalize",
+        "replace",
+        "find",
+        "rfind",
+        "index",
+        "rindex",
+        "count",
+        "isalpha",
+        "isdigit",
+        "isalnum",
+        "isspace",
+        "isupper",
+        "islower",
+        "encode",
+        "format",
+        "center",
+        "ljust",
+        "rjust",
+        "zfill",
+        "partition",
+        "rpartition",
+        "expandtabs",
+        "swapcase",
+        "casefold",
     ];
     if STRING_METHODS.contains(&method) {
         return Some(Type::String);
     }
 
     const DICT_METHODS: &[&str] = &[
-        "get", "items", "keys", "values", "pop", "popitem",
-        "update", "setdefault", "clear", "copy",
+        "get",
+        "items",
+        "keys",
+        "values",
+        "pop",
+        "popitem",
+        "update",
+        "setdefault",
+        "clear",
+        "copy",
     ];
     if DICT_METHODS.contains(&method) {
         return Some(Type::Dict(Box::new(Type::String), Box::new(Type::String)));
@@ -332,9 +351,8 @@ fn infer_from_regex_module(
     args: &[HirExpr],
 ) -> Option<Type> {
     const REGEX_MODULES: &[&str] = &["re", "regex"];
-    const REGEX_METHODS: &[&str] = &[
-        "match", "search", "findall", "sub", "subn", "split", "compile",
-    ];
+    const REGEX_METHODS: &[&str] =
+        &["match", "search", "findall", "sub", "subn", "split", "compile"];
 
     if !REGEX_MODULES.contains(&module_name) || !REGEX_METHODS.contains(&method) {
         return None;
@@ -387,16 +405,26 @@ fn infer_from_subprocess_module(
     None
 }
 
-fn infer_from_string_arg_method(
-    param_name: &str,
-    method: &str,
-    args: &[HirExpr],
-) -> Option<Type> {
+fn infer_from_string_arg_method(param_name: &str, method: &str, args: &[HirExpr]) -> Option<Type> {
     const STRING_ARG_METHODS: &[&str] = &[
-        "find", "search", "match", "sub", "replace", "replace_all",
-        "is_match", "captures", "find_iter", "split", "strip",
-        "lstrip", "rstrip", "startswith", "endswith", "contains",
-        "encode", "decode",
+        "find",
+        "search",
+        "match",
+        "sub",
+        "replace",
+        "replace_all",
+        "is_match",
+        "captures",
+        "find_iter",
+        "split",
+        "strip",
+        "lstrip",
+        "rstrip",
+        "startswith",
+        "endswith",
+        "contains",
+        "encode",
+        "decode",
     ];
     if !STRING_ARG_METHODS.contains(&method) {
         return None;
@@ -424,17 +452,11 @@ fn infer_from_fstring(param_name: &str, parts: &[FStringPart]) -> Option<Type> {
     None
 }
 
-fn infer_from_index_expr(
-    param_name: &str,
-    base: &HirExpr,
-    index: &HirExpr,
-) -> Option<Type> {
+fn infer_from_index_expr(param_name: &str, base: &HirExpr, index: &HirExpr) -> Option<Type> {
     if let HirExpr::Var(var_name) = base {
         if var_name == param_name {
-            let is_string_key = matches!(
-                index,
-                HirExpr::Literal(Literal::String(_)) | HirExpr::FString { .. }
-            );
+            let is_string_key =
+                matches!(index, HirExpr::Literal(Literal::String(_)) | HirExpr::FString { .. });
             let is_likely_string_key = if let HirExpr::Var(idx_name) = index {
                 idx_name == "key" || idx_name == "k" || idx_name.ends_with("_key")
             } else {
@@ -494,16 +516,12 @@ fn infer_from_equality_op(
         return None;
     }
     if let HirExpr::Var(var_name) = left {
-        if var_name == param_name
-            && matches!(right, HirExpr::Literal(Literal::String(_)))
-        {
+        if var_name == param_name && matches!(right, HirExpr::Literal(Literal::String(_))) {
             return Some(Type::String);
         }
     }
     if let HirExpr::Var(var_name) = right {
-        if var_name == param_name
-            && matches!(left, HirExpr::Literal(Literal::String(_)))
-        {
+        if var_name == param_name && matches!(left, HirExpr::Literal(Literal::String(_))) {
             return Some(Type::String);
         }
     }
@@ -544,10 +562,7 @@ fn infer_from_membership_op(
     if let HirExpr::Var(var_name) = left {
         if var_name == param_name {
             if let HirExpr::List(elements) = right {
-                if elements
-                    .iter()
-                    .all(|e| matches!(e, HirExpr::Literal(Literal::String(_))))
-                {
+                if elements.iter().all(|e| matches!(e, HirExpr::Literal(Literal::String(_)))) {
                     return Some(Type::String);
                 }
             }


### PR DESCRIPTION
## Summary
- Auto-formatted with `cargo fmt` (Rust 1.93.0)
- Prerequisite for unified CI lint gate deployment
- No functional changes — formatting only

## Context
Part of unified CI pipeline rollout ([spec](https://github.com/paiml/infra/blob/main/docs/specifications/unified-ci-pipeline.md)).
The lint gate requires `cargo fmt --check` to pass.

Generated with [Claude Code](https://claude.com/claude-code)